### PR TITLE
Use plain text messaging

### DIFF
--- a/chat_window.py
+++ b/chat_window.py
@@ -48,17 +48,9 @@ class ChatWindow(QWidget):
     def enviar_mensaje(self):
         texto = self.input_field.text().strip()
         if texto:
-            mensaje = {
-                "type": "text",
-                "from": self.alias,
-                "uuid": get_client_uuid(),
-                "tunnel_id": self.tunnel_id,
-                "text": texto,
-                "enviado_en": int(time.time() * 1000)
-            }
             try:
-                self.client.send(json.dumps(mensaje) + "\n")
-                self.mostrar_mensaje(f"{texto}")
+                self.client.send(texto + "\n")
+                self.mostrar_mensaje(texto)
                 self.input_field.clear()
             except Exception as e:
                 self.mostrar_mensaje(f"⚠️ Error al enviar el mensaje: {e}")

--- a/ui/panels/tunnel_panel.py
+++ b/ui/panels/tunnel_panel.py
@@ -462,8 +462,8 @@ class TunnelPanel(QWidget):
 
         cliente = self.conexiones_tuneles[tunel_id]["cliente"]
         try:
-            cliente.socket.sendall(mensaje.encode())
-            chat_area.append(f"{mensaje}")
+            cliente.socket.sendall((mensaje + "\n").encode())
+            chat_area.append(mensaje)
             input_field.clear()
         except Exception as e:
             chat_area.append(f"⚠️ Error al enviar mensaje: {e}")


### PR DESCRIPTION
## Summary
- send plain text instead of JSON when sending a chat message
- ensure tunnel panel sends plain text with newline terminator

## Testing
- `python -m py_compile chat_window.py ui/panels/tunnel_panel.py`
- `python -m py_compile main_refactor.py tunnel_client.py db_cliente.py password_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8f43f070832896496baff14790ac