### PR TITLE
Update chat UI colors

### DIFF
--- a/chat_window.py
+++ b/chat_window.py
@@ -33,8 +33,7 @@ class ChatWindow(QWidget):
                 border: none;
             }
             QWidget {
-                background-image: url(assets/bg_dark_texture.png);
-                background-repeat: repeat;
+                background-color: #000;
             }
         """)
 

--- a/message_bubble.py
+++ b/message_bubble.py
@@ -23,7 +23,7 @@ class MessageBubble(QWidget):
         text_label.setWordWrap(True)
         text_label.setStyleSheet("""
             padding: 6px;
-            background-color: #DCF8C6;
+            background-color: #00BCD4;
             border-radius: 8px;
         """ if is_sender else """
             padding: 6px;


### PR DESCRIPTION
## Summary
- remove background image from chat scroll area
- set outgoing chat bubbles to turquoise

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd7a8aa808328a42304d04c058a3d