### PR TITLE
Fix try block and refactor download

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -135,6 +135,10 @@ def _extraer_texto(payload):
             return payload["text"]
         if "contenido" in payload:
             return payload["contenido"]
+        # Si contiene URL o nombre de archivo, devolver esos valores en lugar
+        # de la representación completa del objeto
+        if "url" in payload or "filename" in payload:
+            return payload.get("url") or payload.get("filename")
         return str(payload)
 
     if isinstance(payload, bytes):

--- a/chat_window.py
+++ b/chat_window.py
@@ -184,6 +184,9 @@ class ChatWindow(QWidget):
                     self.mostrar_mensaje("⚠️ No se pudo descargar el archivo.")
                     return
 
+        except Exception as e:
+            self.mostrar_mensaje(f"⚠️ Error al procesar mensaje: {e}", "Sistema", True)
+
     def download_file(self, url, nombre):
         try:
             respuesta = requests.get(f"http://symbolsaps.ddns.net:8000{url}", stream=True)
@@ -195,15 +198,9 @@ class ChatWindow(QWidget):
             if ruta_guardado:
                 from PyQt5.QtWidgets import QProgressDialog
 
-                    with open(ruta_guardado, "wb") as f:
-                        downloaded = 0
-                        for chunk in respuesta.iter_content(chunk_size=8192):
-                            if progress.wasCanceled():
-                                self.mostrar_mensaje("⛔ Descarga cancelada por el usuario.")
-                                return
-                            f.write(chunk)
-                            downloaded += len(chunk)
-                            progress.setValue(downloaded)
+                progress = QProgressDialog("Descargando archivo...", "Cancelar", 0, 0, self)
+                progress.setWindowModality(Qt.WindowModal)
+                progress.show()
 
                 with open(ruta_guardado, "wb") as f:
                     downloaded = 0


### PR DESCRIPTION
## Summary
- handle error case when processing a message
- refactor `download_file` logic to remove indentation issue and add a progress dialog

## Testing
- `python3 -m py_compile chat_window.py main_refactor.py`
- `python3 main_refactor.py` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_684ed29341388328bebe583c63c916d7