### PR TITLE
Handle file download on single click

### DIFF
--- a/chat_window.py
+++ b/chat_window.py
@@ -187,7 +187,9 @@ class ChatWindow(QWidget):
 
     def download_file(self, url, nombre):
         try:
-            respuesta = requests.get(f"http://symbolsaps.ddns.net:8000{url}", stream=True)
+            if not url.startswith("http"):
+                url = f"http://symbolsaps.ddns.net:8000{url}"
+            respuesta = requests.get(url, stream=True)
             if respuesta.status_code != 200:
                 self.mostrar_mensaje("⚠️ No se pudo descargar el archivo.")
                 return

--- a/ui/panels/tunnel_panel.py
+++ b/ui/panels/tunnel_panel.py
@@ -137,7 +137,8 @@ class TunnelPanel(QWidget):
 
         self.files_list = QListWidget()
         self.files_list.setFixedWidth(215)
-        self.files_list.itemDoubleClicked.connect(self._download_file_from_list)
+        # Descargar el archivo con un solo clic
+        self.files_list.itemClicked.connect(self._download_file_from_list)
         right_panel.addWidget(self.files_list)
 
         right_container = QWidget()


### PR DESCRIPTION
## Summary
- connect itemClicked instead of itemDoubleClicked for file list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ee04bb76c8328a8ee052a76aa5eac